### PR TITLE
Adding contributors to main readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,14 @@ Kudos! Your contribution is greatly appreciated.
 <img src="https://c.tenor.com/kEOz87vlud0AAAAC/minions-yahoo.gif" />
 </div>
 
+## Contributors
+
+<a href="https://github.com/DiyaVj/Profile-Card-Collection/graphs/contributors">
+  <p align="center">
+    <img width="720" src="https://contrib.rocks/image?repo=DiyaVj/Profile-Card-Collection" alt="A table of avatars from the project's contributors" />
+  </p>
+</a>
+
+<p align="center">
+  Made with <a rel="noopener noreferrer" target="_blank" href="https://contrib.rocks">contrib.rocks</a>
+</p>


### PR DESCRIPTION
This PR adds image of contributors' avatars auto generated by contrib.rock to main readme.md. If there's anything that need to be changed, please let me know!